### PR TITLE
Improve weekly report generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ configured under `/data/snowdrop-bot` which which is a volume friendlier path
 #### Persistence and configuration (production)
 The production profile uses /data/snowdrop-bot as the root for configuration and database files.
 
+## Associate list
+
+The associate table can be maintained with the following REST services:
+
+```bash
+$ curl -X PUT -d associate=<github-id> -d alias=<bot-alias> -d source=[GITHUB,JIRA,...] -d name="<Associante Name>" localhost:8080/associate/create
+```
+
+A list of the associates can be obtained using the list service.
+
+```bash
+$ curl -X GET localhost:8080/associate/list
+```
+
 ## Issue tracking
 
 Provides a unified view of all `active` issues across multiple repositories.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A bot for automating snowdrop related tasks
 
 ## Installation
 
-To prevent adding personal information to github, create an alternate resources folder at `src/main/local-resources` and copy the `src/main/resources/application.properties` 
+To prevent adding personal information to github, create an alternate resources folder at `src/main/local-resources` and copy the `src/main/resources/application.properties`
 file into it. All changes should be made to this file. This folder is excluded in `.gitignore`.
 
 ### Database
@@ -49,7 +49,7 @@ The application will need to access github. So you are going to need an access
 token.
 
 The token can be configured either via `github.token` property or `GITHUB_TOKEN`
-environment variable. 
+environment variable.
 
 > NOTE: The `github.token` property is configured to have it's value filled with the [Maven Rsource plugin Filter capabilities](https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html).
 > It can be easilly filled by adding -Dgithub.token=<the token> to the maven compilation statement.
@@ -89,8 +89,8 @@ To run the bot you can just build:
 
 If using resource filtering use build it this way instead:
 
-    ./mvnw -Dgithub.token=<the token> clean package 
-    
+    ./mvnw -Dgithub.token=<the token> clean package
+
 and then run with:
 
     java -jar target/snowdrop-bot-0.1-SNAPSHOT-runner.jar
@@ -99,7 +99,7 @@ and then run with:
 `application.properites` or create an environment variable for it.
 
 ### Default Profile
-To avoid unnecessary trafic on the github API (which is subject of rate
+To avoid unnecessary traffic on the github API (which is subject of rate
 limiting) the default profile has the core features (e.g. bridge and reporting disabled).
 
 You can enable them selectively through the UI, or use a different profile (e.g.
@@ -125,7 +125,7 @@ The criteria for selecting issues are the following:
 
 - exist in repositories of configured organizations (`github.reporting.organizations`)
 - assigned to configured users (`github.users`)
-- the assigned user has forked the repository 
+- the assigned user has forked the repository
 - were open within the configured time frame (the week bounded by `github.reporting.day-of-week` & `github.reporting.hours`)
 
 Those issues, can be exported in csv, excel or pdf.
@@ -142,7 +142,7 @@ The criteria for selecting issues are the following:
 
 - exist in repositories of configured organizations (`github.reporting.organizations`)
 - assigned to configured users (`github.users`)
-- the assigned user has forked the repository 
+- the assigned user has forked the repository
 - were open within the configured time frame (the week bounded by `github.reporting.day-of-week` & `github.reporting.hours`)
 
 ![pull request screen](./img/pull-requests.png "Pull Requests Screen")
@@ -158,7 +158,7 @@ When working across multiple different organizations owned by different teams
 with variable access levels, its important to be able to have an aggregated view
 of the pending issues. This is important for things like:
 
-- tracking 
+- tracking
 - scheduling
 - reporting
 

--- a/src/main/java/io/snowdrop/reporting/associate/AssociateEndpoint.java
+++ b/src/main/java/io/snowdrop/reporting/associate/AssociateEndpoint.java
@@ -1,0 +1,76 @@
+package io.snowdrop.reporting.associate;
+
+import java.util.List;
+
+import javax.transaction.Transactional;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.snowdrop.reporting.model.Associate;
+import io.snowdrop.reporting.model.IssueSource;
+
+/**
+ * <p>
+ * Manages associates.
+ * </p>
+ * curl -X PUT http://localhost:8080/associate/create?alias=jacobdotcosta
+ */
+@Path("/associate")
+public class AssociateEndpoint {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AssociateEndpoint.class);
+
+  @PUT
+  @Path("/create")
+  @Produces(MediaType.TEXT_PLAIN)
+  @Transactional
+  public Response createAssociate(
+  @FormParam("associate") String associate,
+  @FormParam("alias") String alias,
+  @FormParam("source") String source,
+  @FormParam("name") String name) {
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("#createAssociate(String,String,String) - {},{},{},{}", associate, alias, source, name);
+    }
+    Associate storedAssociate = Associate.findById(associate);
+    IssueSource issueSource = IssueSource.valueOf(source);
+    if (storedAssociate == null) {
+      storedAssociate = Associate.create(associate, alias, issueSource.name(), name);
+      storedAssociate.persist();
+      return Response.accepted(storedAssociate).build();
+    } else {
+      return Response.notModified().build();
+    }
+  }
+
+  @GET
+  @Path("/list")
+  @Produces(MediaType.APPLICATION_JSON)
+  public List<Associate> listAssociates() {
+    return Associate.listAll();
+  }
+
+  @POST
+  @Path("/delete")
+  @Produces(MediaType.TEXT_PLAIN)
+  public Response delete(@FormParam("associate") String associate) {
+     Associate storedAssociate = Associate.findById(associate);
+     if (storedAssociate != null) {
+       storedAssociate.delete();
+       return Response.accepted().build();
+     } else {
+       return Response.notModified().build();
+     }
+  }
+
+}

--- a/src/main/java/io/snowdrop/reporting/model/Associate.java
+++ b/src/main/java/io/snowdrop/reporting/model/Associate.java
@@ -1,0 +1,115 @@
+package io.snowdrop.reporting.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+
+@Entity
+public class Associate extends PanacheEntityBase {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(Associate.class);
+
+  @Id
+  String associate;
+  String alias;
+  String source;
+  String name;
+
+  public Associate() {
+  }
+
+  public Associate(final String associate, final String alias, final String source, final String name) {
+    this.associate = associate;
+    this.alias = alias;
+    this.source = source;
+    this.name = name;
+  }
+
+  public static Associate create(final String associate, final String alias, final String source, final String name) {
+    return new Associate(associate, alias, source, name);
+  }
+
+  /**
+   * <p>Gets the name of an associate.</p>
+   * @param associate
+   * @param issueSource
+   * @return
+   */
+  public static String getAssociateName(final String associate, final IssueSource issueSource) {
+    String associateName;
+    Associate storedAssociate = Associate.findById(associate);
+    if (storedAssociate != null) {
+      associateName = storedAssociate.getName();
+    } else {
+      associateName = associate;
+    }
+    return associateName;
+  }
+
+  public String getAssociate() {
+    return associate;
+  }
+
+  public void setAssociate(final String associate) {
+    this.associate = associate;
+  }
+
+  public String getAlias() {
+    return alias;
+  }
+
+  public void setAlias(final String alias) {
+    this.alias = alias;
+  }
+
+  public String getSource() {
+    return source;
+  }
+
+  public void setSource(final String source) {
+    this.source = source;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((associate == null) ? 0 : associate.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Associate other = (Associate) obj;
+    if (associate == null) {
+      if (other.associate != null)
+        return false;
+    } else if (!associate.equals(other.associate))
+      return false;
+    return true;
+  }
+
+  @Override public String toString() {
+    StringBuffer sb = new StringBuffer("{associate: ").append(associate).append(", alias: ").append(alias).append(", source: ").append(source)
+    .append(", name: ").append(name).append("}");
+    return sb.toString();
+  }
+}

--- a/src/main/java/io/snowdrop/reporting/model/Issue.java
+++ b/src/main/java/io/snowdrop/reporting/model/Issue.java
@@ -20,8 +20,6 @@ public class Issue extends PanacheEntityBase implements WithDates {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Issue.class);
 
-  // private static final DateTimeFormatter DF = DateTimeFormat.forPattern("yyyy/MM/dd'T'HH:mm:ss.SZ");
-
   private static final SimpleDateFormat DF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
   @Id
@@ -128,8 +126,9 @@ public class Issue extends PanacheEntityBase implements WithDates {
    * @return
    */
   public static PanacheQuery<Issue> findByIssuesForWeeklyDevelopmentReport(final String prepository, final Date pdateFrom, final Date pdateTo) {
-    return Issue.find("((repository != ?1 AND updatedAt >= ?2 AND updatedAt <= ?3) OR (repository = ?1 AND ((updatedAt >= ?2 AND updatedAt <= ?3) OR open = true))) AND (label != 'report' or label is null) AND assignee is not null",
-    Sort.ascending("assignee", "label", "updatedAt"), prepository, pdateFrom, pdateTo);
+    return Issue.find(
+    "((repository != ?1 AND updatedAt >= ?2 AND updatedAt <= ?3) OR (repository = ?1 AND ((updatedAt >= ?2 AND updatedAt <= ?3) OR open = true))) AND (label != 'report' or label is null) AND assignee is not null and source = ?4",
+    Sort.ascending("assignee", "label", "updatedAt"), prepository, pdateFrom, pdateTo, IssueSource.GITHUB.name());
   }
 
   /**

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeekReportEndpoint.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeekReportEndpoint.java
@@ -60,6 +60,18 @@ public class WeekReportEndpoint {
   @ConfigProperty(name = "github.reporting.target.repository")
   String repoName;
 
+  @ConfigProperty(name = "report.state.closed")
+  String mdClosedFormat;
+
+  @ConfigProperty(name = "report.state.open")
+  String mdOpenFormat;
+
+  @ConfigProperty(name = "report.state.old")
+  String mdOldFormat;
+
+  @ConfigProperty(name = "report.state.ancient")
+  String mdAncientFormat;
+
   @Inject
   GitHubClient client;
 
@@ -86,7 +98,8 @@ public class WeekReportEndpoint {
 
   private String generateReport(final Date startTime, final Date endTime, String reportName) {
     populate(startTime, endTime);
-    final String mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users).buildWeeklyReport(reportName);
+    final String mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users, mdOpenFormat, mdOldFormat, mdAncientFormat, mdClosedFormat)
+    .buildWeeklyReport(reportName);
     LOGGER.info("{}: {}", reportName, mdText);
     return mdText;
   }
@@ -106,15 +119,6 @@ public class WeekReportEndpoint {
       LOGGER.debug("week number: {}", weekNumber);
       final String reportName = String.format(reportNameTemplate, weekNumber);
       return generateReport(startTime, endTime, reportName);
-      //      Date startTime = startTimeString != null ? DF.parse(startTimeString) : Date.from(service.getPullRequestCollector().getStartTime().toInstant());
-      //      Date endTime = endTimeString != null ? DF.parse(endTimeString) : Date.from(service.getPullRequestCollector().getEndTime().toInstant());
-      //      weekNumber = WEEK_YEAR_FORMAT.format(endTime);
-      //      LOGGER.debug("week number: {}", weekNumber);
-      //      final String reportName = String.format(reportNameTemplate, weekNumber);
-      //      populate(startTime, endTime);
-      //      mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users).buildWeeklyReport(reportName);
-      //      LOGGER.info("{}}: {}", reportName, mdText);
-      //      return mdText;
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
       throw BotException.launderThrowable(e);

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeekReportEndpoint.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeekReportEndpoint.java
@@ -1,6 +1,7 @@
 package io.snowdrop.reporting.weekreport;
 
 import java.io.IOException;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -48,6 +49,8 @@ public class WeekReportEndpoint {
   private static final String REPO_DEV_PREFIX = "";
   private static final String REPO_WEEK_DEV_PREFIX = "";
 
+  private final String reportNameTemplate = "Weekly Report - %s";
+
   @ConfigProperty(name = "github.users")
   Set<String> users;
 
@@ -81,6 +84,13 @@ public class WeekReportEndpoint {
     }).collect(Collectors.toSet());
   }
 
+  private String generateReport(final Date startTime, final Date endTime, String reportName) {
+    populate(startTime, endTime);
+    final String mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users).buildWeeklyReport(reportName);
+    LOGGER.info("{}: {}", reportName, mdText);
+    return mdText;
+  }
+
   @GET
   @Path("/generate")
   @Produces(MediaType.TEXT_PLAIN)
@@ -88,22 +98,31 @@ public class WeekReportEndpoint {
   public String createReport(
   @QueryParam("startTime") String startTimeString,
   @QueryParam("endTime") String endTimeString) {
-    String mdText;
-    String weekNumber;
     IssueService issueService = new IssueService(client);
     try {
-      Date startTime = startTimeString != null ? DF.parse(startTimeString) : Date.from(service.getPullRequestCollector().getStartTime().toInstant());
-      Date endTime = endTimeString != null ? DF.parse(endTimeString) : Date.from(service.getPullRequestCollector().getEndTime().toInstant());
-      weekNumber = WEEK_YEAR_FORMAT.format(endTime);
+      final Date startTime = parseDate(startTimeString);
+      final Date endTime = parseDate(endTimeString);
+      final String weekNumber = WEEK_YEAR_FORMAT.format(endTime);
       LOGGER.debug("week number: {}", weekNumber);
-      populate(startTime, endTime);
-      mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users).buildWeeklyReport();
-      LOGGER.info("weekly_development: {}", mdText);
-      return mdText;
+      final String reportName = String.format(reportNameTemplate, weekNumber);
+      return generateReport(startTime, endTime, reportName);
+      //      Date startTime = startTimeString != null ? DF.parse(startTimeString) : Date.from(service.getPullRequestCollector().getStartTime().toInstant());
+      //      Date endTime = endTimeString != null ? DF.parse(endTimeString) : Date.from(service.getPullRequestCollector().getEndTime().toInstant());
+      //      weekNumber = WEEK_YEAR_FORMAT.format(endTime);
+      //      LOGGER.debug("week number: {}", weekNumber);
+      //      final String reportName = String.format(reportNameTemplate, weekNumber);
+      //      populate(startTime, endTime);
+      //      mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users).buildWeeklyReport(reportName);
+      //      LOGGER.info("{}}: {}", reportName, mdText);
+      //      return mdText;
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);
       throw BotException.launderThrowable(e);
     }
+  }
+
+  private Date parseDate(final String timeString) throws ParseException {
+    return timeString != null ? DF.parse(timeString) : Date.from(service.getPullRequestCollector().getStartTime().toInstant());
   }
 
   @GET
@@ -113,18 +132,15 @@ public class WeekReportEndpoint {
   public String publishReport(
   @QueryParam("startTime") String startTimeString,
   @QueryParam("endTime") String endTimeString) {
-    String mdText;
-    String weekNumber;
     IssueService issueService = new IssueService(client);
     try {
-      Date startTime = startTimeString != null ? DF.parse(startTimeString) : Date.from(service.getPullRequestCollector().getStartTime().toInstant());
-      Date endTime = endTimeString != null ? DF.parse(endTimeString) : Date.from(service.getPullRequestCollector().getEndTime().toInstant());
-      weekNumber = WEEK_YEAR_FORMAT.format(endTime);
+      final Date startTime = parseDate(startTimeString);
+      final Date endTime = parseDate(endTimeString);
+      final String weekNumber = WEEK_YEAR_FORMAT.format(endTime);
       LOGGER.debug("week number: {}", weekNumber);
-      populate(startTime, endTime);
-      mdText = WeeklyDevelopmentReportImpl.build(startTime, endTime, users).buildWeeklyReport();
-      LOGGER.info("weekly_development: {}", mdText);
-      updateGithubIssue(mdText, "weekly_development_" + weekNumber, "report", issueService, repoOrganization, repoName);
+      final String reportName = String.format(reportNameTemplate, weekNumber);
+      final String mdText = generateReport(startTime, endTime, reportName);
+      updateGithubIssue(mdText, reportName, "report", issueService, repoOrganization, repoName);
       return mdText;
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
@@ -6,6 +6,9 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.snowdrop.reporting.MarkdownHelper;
 import io.snowdrop.reporting.ReportConstants;
 import io.snowdrop.reporting.model.Associate;
@@ -30,6 +33,8 @@ import net.steppschuh.markdowngenerator.text.TextBuilder;
  */
 public class WeeklyDevelopmentReportImpl {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(WeeklyDevelopmentReportImpl.class);
+
   /**
    * <p>Users to which the report will be applied</p>
    */
@@ -45,14 +50,38 @@ public class WeeklyDevelopmentReportImpl {
    */
   protected Date endDate = null;
 
-  public WeeklyDevelopmentReportImpl(final Date pStartDate, final Date pEndDate, final Set<String> pusers) {
-    users = pusers;
-    startDate = pStartDate;
-    endDate = pEndDate;
+  String mdClosedFormat = null;
+
+  String mdOpenFormat = null;
+
+  String mdOldFormat = null;
+
+  String mdAncientFormat = null;
+
+  public WeeklyDevelopmentReportImpl(
+  final Date startDate,
+  final Date endDate,
+  final Set<String> users,
+  final String mdOpenFormat,
+  final String mdOldFormat,
+  final String mdAncientFormat,
+  final String mdClosedFormat) {
+    this.users = users;
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.mdAncientFormat = mdAncientFormat;
+    this.mdClosedFormat = mdClosedFormat;
+    this.mdOldFormat = mdOldFormat;
+    this.mdOpenFormat = mdOpenFormat;
   }
 
-  public static WeeklyDevelopmentReportImpl build(final Date pStartDate, final Date pEndDate, final Set<String> pusers) {
-    return new WeeklyDevelopmentReportImpl(pStartDate, pEndDate, pusers);
+  public static WeeklyDevelopmentReportImpl build(
+  final Date startDate, final Date endDate, final Set<String> users,
+  final String mdOpenFormat,
+  final String mdOldFormat,
+  final String mdAncientFormat,
+  final String mdClosedFormat) {
+    return new WeeklyDevelopmentReportImpl(startDate, endDate, users, mdOpenFormat, mdOldFormat, mdAncientFormat, mdClosedFormat);
   }
 
   /**
@@ -80,17 +109,18 @@ public class WeeklyDevelopmentReportImpl {
         eachLabel.getValue().stream().forEach(eachIssue -> {
           TextBuilder issueTextB = new TextBuilder();
           Date dateCreatedAt = eachIssue.getCreatedAt();
-          String strMdColor = " ![#a9a9a9](https://via.placeholder.com/15/a9a9a9/000000?text=+) ";
+          String strMdColor = mdClosedFormat;
           if (eachIssue.isOpen()) {
+            strMdColor = mdOpenFormat;
             if (dateCreatedAt.toInstant().isBefore(oneMonthAgo.toInstant())) {
-              strMdColor = " ![#ff0000](https://via.placeholder.com/15/ff0000/000000?text=+) ";
+              strMdColor = mdAncientFormat;
             } else if (dateCreatedAt.toInstant().isBefore(twoWeeksAgo.toInstant())) {
-              strMdColor = " ![#ffaa00](https://via.placeholder.com/15/ffaa00/000000?text=+) ";
-            } else {
-              strMdColor = " ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+) ";
+              strMdColor = mdOldFormat;
             }
           }
-          issueTextB.append(new Text( strMdColor )).append("[`").append(eachIssue.getStatus()).append("`] ").append(eachIssue.getTitle()).append(" - ").append(new Link(eachIssue.getUrl()));
+          issueTextB.append(new Text(" ")).append(strMdColor).append(" [`").append(eachIssue.getStatus()).append("`] ").append(eachIssue.getTitle())
+          .append(" - ")
+          .append(new Link(eachIssue.getUrl()));
           issueUnorderedList.getItems().add(issueTextB);
         });
         labelUnorderedList.getItems().add(issueUnorderedList);

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
@@ -7,7 +7,9 @@ import java.util.stream.Collectors;
 
 import io.snowdrop.reporting.MarkdownHelper;
 import io.snowdrop.reporting.ReportConstants;
+import io.snowdrop.reporting.model.Associate;
 import io.snowdrop.reporting.model.Issue;
+import io.snowdrop.reporting.model.IssueSource;
 import net.steppschuh.markdowngenerator.MarkdownSerializationException;
 import net.steppschuh.markdowngenerator.link.Link;
 import net.steppschuh.markdowngenerator.list.UnorderedList;
@@ -57,17 +59,18 @@ public class WeeklyDevelopmentReportImpl {
    *
    * @return
    */
-  public String buildWeeklyReport() {
-    StringBuilder sb = new StringBuilder();
+  public String buildWeeklyReport(String reportName) {
+    StringBuilder sb = new StringBuilder(MarkdownHelper.addHeadingTitle(reportName, 1)).append(ReportConstants.CR);
     ZonedDateTime now = ZonedDateTime.now();
     ZonedDateTime twoWeeksAgo = now.minusWeeks(2);
     ZonedDateTime oneMonthAgo = now.minusMonths(1);
     String repoName = ReportConstants.WEEK_DEV_REPO_OWNER + "/" + ReportConstants.WEEK_DEV_REPO_NAME;
     Issue.findByIssuesForWeeklyDevelopmentReport(repoName, startDate, endDate).list().stream()
-        .collect(Collectors.groupingBy(Issue::getAssignee, Collectors.toSet()))
-        .entrySet().forEach(eachAssignee -> {
+    .collect(Collectors.groupingBy(Issue::getAssignee, Collectors.toSet()))
+    .entrySet().forEach(eachAssignee -> {
       String assignee = eachAssignee.getKey();
-      sb.append(ReportConstants.CR).append(ReportConstants.CR).append(MarkdownHelper.addHeadingTitle(assignee, 2)).append(ReportConstants.CR);
+      String associateName = Associate.getAssociateName(assignee, IssueSource.GITHUB);
+      sb.append(ReportConstants.CR).append(ReportConstants.CR).append(MarkdownHelper.addHeadingTitle(associateName, 2)).append(ReportConstants.CR);
       UnorderedList labelUnorderedList = new UnorderedList();
       eachAssignee.getValue().stream().collect(Collectors.groupingBy(Issue::getLabel, Collectors.toSet())).entrySet().forEach(eachLabel -> {
         String label = eachLabel.getKey();
@@ -76,18 +79,23 @@ public class WeeklyDevelopmentReportImpl {
         eachLabel.getValue().stream().forEach(eachIssue -> {
           TextBuilder issueTextB = new TextBuilder();
           Date dateCreatedAt = eachIssue.getCreatedAt();
-          String strMdColor = "gray";
-          if(eachIssue.isOpen()) {
+//          String strMdColor = "gray";
+          String strMdColor = " ![#a9a9a9](https://via.placeholder.com/15/a9a9a9/000000?text=+) ";
+          if (eachIssue.isOpen()) {
             if (dateCreatedAt.toInstant().isBefore(oneMonthAgo.toInstant())) {
-              strMdColor = "red";
+//              strMdColor = "red";
+              strMdColor = " ![#ff0000](https://via.placeholder.com/15/ff0000/000000?text=+) ";
             } else if (dateCreatedAt.toInstant().isBefore(twoWeeksAgo.toInstant())) {
-              strMdColor = "orange";
+//              strMdColor = "orange";
+              strMdColor = " ![#ffaa00](https://via.placeholder.com/15/ffaa00/000000?text=+) ";
             } else {
-              strMdColor = "green";
+//              strMdColor = "green";
+              strMdColor = " ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+) ";
             }
           }
-          issueTextB.append(new Text("<span style=\"color:" + strMdColor + "\">[")).append(eachIssue.getStatus())
-              .append("]</span> ").append(eachIssue.getTitle()).append(" - ").append(new Link(eachIssue.getUrl()));
+//          issueTextB.append(new Text("<span style=\"color:" + strMdColor + "\">[")).append(eachIssue.getStatus())
+//          .append("]</span> ").append(eachIssue.getTitle()).append(" - ").append(new Link(eachIssue.getUrl()));
+          issueTextB.append(new Text( strMdColor )).append("[`").append(eachIssue.getStatus()).append("`] ").append(eachIssue.getTitle()).append(" - ").append(new Link(eachIssue.getUrl()));
           issueUnorderedList.getItems().add(issueTextB);
         });
         labelUnorderedList.getItems().add(issueUnorderedList);

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
@@ -3,6 +3,7 @@ package io.snowdrop.reporting.weekreport;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import io.snowdrop.reporting.MarkdownHelper;
@@ -66,35 +67,29 @@ public class WeeklyDevelopmentReportImpl {
     ZonedDateTime oneMonthAgo = now.minusMonths(1);
     String repoName = ReportConstants.WEEK_DEV_REPO_OWNER + "/" + ReportConstants.WEEK_DEV_REPO_NAME;
     Issue.findByIssuesForWeeklyDevelopmentReport(repoName, startDate, endDate).list().stream()
-    .collect(Collectors.groupingBy(Issue::getAssignee, Collectors.toSet()))
+    .collect(Collectors.groupingBy(Issue::getAssignee, TreeMap::new, Collectors.toSet()))
     .entrySet().forEach(eachAssignee -> {
       String assignee = eachAssignee.getKey();
       String associateName = Associate.getAssociateName(assignee, IssueSource.GITHUB);
       sb.append(ReportConstants.CR).append(ReportConstants.CR).append(MarkdownHelper.addHeadingTitle(associateName, 2)).append(ReportConstants.CR);
       UnorderedList labelUnorderedList = new UnorderedList();
-      eachAssignee.getValue().stream().collect(Collectors.groupingBy(Issue::getLabel, Collectors.toSet())).entrySet().forEach(eachLabel -> {
+      eachAssignee.getValue().stream().collect(Collectors.groupingBy(Issue::getLabel, TreeMap::new, Collectors.toSet())).entrySet().forEach(eachLabel -> {
         String label = eachLabel.getKey();
         labelUnorderedList.getItems().add(label);
         UnorderedList issueUnorderedList = new UnorderedList();
         eachLabel.getValue().stream().forEach(eachIssue -> {
           TextBuilder issueTextB = new TextBuilder();
           Date dateCreatedAt = eachIssue.getCreatedAt();
-//          String strMdColor = "gray";
           String strMdColor = " ![#a9a9a9](https://via.placeholder.com/15/a9a9a9/000000?text=+) ";
           if (eachIssue.isOpen()) {
             if (dateCreatedAt.toInstant().isBefore(oneMonthAgo.toInstant())) {
-//              strMdColor = "red";
               strMdColor = " ![#ff0000](https://via.placeholder.com/15/ff0000/000000?text=+) ";
             } else if (dateCreatedAt.toInstant().isBefore(twoWeeksAgo.toInstant())) {
-//              strMdColor = "orange";
               strMdColor = " ![#ffaa00](https://via.placeholder.com/15/ffaa00/000000?text=+) ";
             } else {
-//              strMdColor = "green";
               strMdColor = " ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+) ";
             }
           }
-//          issueTextB.append(new Text("<span style=\"color:" + strMdColor + "\">[")).append(eachIssue.getStatus())
-//          .append("]</span> ").append(eachIssue.getTitle()).append(" - ").append(new Link(eachIssue.getUrl()));
           issueTextB.append(new Text( strMdColor )).append("[`").append(eachIssue.getStatus()).append("`] ").append(eachIssue.getTitle()).append(" - ").append(new Link(eachIssue.getUrl()));
           issueUnorderedList.getItems().add(issueTextB);
         });

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
@@ -106,22 +106,24 @@ public class WeeklyDevelopmentReportImpl {
         String label = eachLabel.getKey();
         labelUnorderedList.getItems().add(label);
         UnorderedList issueUnorderedList = new UnorderedList();
-        eachLabel.getValue().stream().forEach(eachIssue -> {
-          TextBuilder issueTextB = new TextBuilder();
-          Date dateCreatedAt = eachIssue.getCreatedAt();
-          String strMdColor = mdClosedFormat;
-          if (eachIssue.isOpen()) {
-            strMdColor = mdOpenFormat;
-            if (dateCreatedAt.toInstant().isBefore(oneMonthAgo.toInstant())) {
-              strMdColor = mdAncientFormat;
-            } else if (dateCreatedAt.toInstant().isBefore(twoWeeksAgo.toInstant())) {
-              strMdColor = mdOldFormat;
+        eachLabel.getValue().stream().collect(Collectors.groupingBy(Issue::getStatus, TreeMap::new, Collectors.toSet())).entrySet().forEach(eachStatus -> {
+          eachStatus.getValue().stream().forEach(eachIssue -> {
+            TextBuilder issueTextB = new TextBuilder();
+            Date dateCreatedAt = eachIssue.getCreatedAt();
+            String strMdColor = mdClosedFormat;
+            if (eachIssue.isOpen()) {
+              strMdColor = mdOpenFormat;
+              if (dateCreatedAt.toInstant().isBefore(oneMonthAgo.toInstant())) {
+                strMdColor = mdAncientFormat;
+              } else if (dateCreatedAt.toInstant().isBefore(twoWeeksAgo.toInstant())) {
+                strMdColor = mdOldFormat;
+              }
             }
-          }
-          issueTextB.append(new Text(" ")).append(strMdColor).append(" [`").append(eachIssue.getStatus()).append("`] ").append(eachIssue.getTitle())
-          .append(" - ")
-          .append(new Link(eachIssue.getUrl()));
-          issueUnorderedList.getItems().add(issueTextB);
+            issueTextB.append(new Text(" ")).append(strMdColor).append(" [`").append(eachIssue.getStatus()).append("`] ").append(eachIssue.getTitle())
+            .append(" - ")
+            .append(new Link(eachIssue.getUrl()));
+            issueUnorderedList.getItems().add(issueTextB);
+          });
         });
         labelUnorderedList.getItems().add(issueUnorderedList);
       });
@@ -134,16 +136,16 @@ public class WeeklyDevelopmentReportImpl {
     sb.append(ReportConstants.CR).append(ReportConstants.CR).append(MarkdownHelper.addHeadingTitle("Legend", 2)).append(ReportConstants.CR);
     UnorderedList legendUnorderedList = new UnorderedList();
     TextBuilder legendTextB = new TextBuilder();
-    legendTextB.append(new Text(" ")).append(mdOpenFormat).append(" : OPEN, with creation date less than 2 weeks");
+    legendTextB.append(new Text(" ")).append(mdOpenFormat).append(" : Open but age <= 2 weeks");
     legendUnorderedList.getItems().add(legendTextB);
     legendTextB = new TextBuilder();
-    legendTextB.append(new Text(" ")).append(mdOldFormat).append(" : OPEN, with creation date between 2 weeks and 1 month");
+    legendTextB.append(new Text(" ")).append(mdOldFormat).append(" : Open but age is >= 2 weeks & <  1month");
     legendUnorderedList.getItems().add(legendTextB);
     legendTextB = new TextBuilder();
-    legendTextB.append(new Text(" ")).append(mdAncientFormat).append(" : OPEN, with creation date older 1 month");
+    legendTextB.append(new Text(" ")).append(mdAncientFormat).append(" : Open but age > 1 month");
     legendUnorderedList.getItems().add(legendTextB);
     legendTextB = new TextBuilder();
-    legendTextB.append(new Text(" ")).append(mdClosedFormat).append(" : CLOSED");
+    legendTextB.append(new Text(" ")).append(mdClosedFormat).append(" : Close");
     legendUnorderedList.getItems().add(legendTextB);
     try {
       sb.append(legendUnorderedList.serialize());

--- a/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
+++ b/src/main/java/io/snowdrop/reporting/weekreport/WeeklyDevelopmentReportImpl.java
@@ -131,6 +131,25 @@ public class WeeklyDevelopmentReportImpl {
         pE.printStackTrace();
       }
     });
+    sb.append(ReportConstants.CR).append(ReportConstants.CR).append(MarkdownHelper.addHeadingTitle("Legend", 2)).append(ReportConstants.CR);
+    UnorderedList legendUnorderedList = new UnorderedList();
+    TextBuilder legendTextB = new TextBuilder();
+    legendTextB.append(new Text(" ")).append(mdOpenFormat).append(" : OPEN, with creation date less than 2 weeks");
+    legendUnorderedList.getItems().add(legendTextB);
+    legendTextB = new TextBuilder();
+    legendTextB.append(new Text(" ")).append(mdOldFormat).append(" : OPEN, with creation date between 2 weeks and 1 month");
+    legendUnorderedList.getItems().add(legendTextB);
+    legendTextB = new TextBuilder();
+    legendTextB.append(new Text(" ")).append(mdAncientFormat).append(" : OPEN, with creation date older 1 month");
+    legendUnorderedList.getItems().add(legendTextB);
+    legendTextB = new TextBuilder();
+    legendTextB.append(new Text(" ")).append(mdClosedFormat).append(" : CLOSED");
+    legendUnorderedList.getItems().add(legendTextB);
+    try {
+      sb.append(legendUnorderedList.serialize());
+    } catch (MarkdownSerializationException pE) {
+      pE.printStackTrace();
+    }
     return sb.toString();
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,8 +43,8 @@ jira.users=
 ##########
 report.weekly.name=Weekly Report
 
-report.state.closed=  ![#a9a9a9](https://via.placeholder.com/15/a9a9a9/000000?text=+)
-report.state.open=  ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+)
+report.state.closed=  ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+)
+report.state.open=  ![#0000ff](https://via.placeholder.com/15/0000ff/000000?text=+)
 report.state.old=  ![#ffaa00](https://via.placeholder.com/15/ffaa00/000000?text=+)
 report.state.ancient=  ![#ff0000](https://via.placeholder.com/15/ff0000/000000?text=+)
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -38,6 +38,11 @@ jira.url=https://issues.redhat.com
 jira.reporting.repos=
 jira.users=
 
+##########
+# Report #
+##########
+report.weekly.name=Weekly Report
+
 #
 # Hibernate Configuraton
 #

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,6 +43,11 @@ jira.users=
 ##########
 report.weekly.name=Weekly Report
 
+report.state.closed=  ![#a9a9a9](https://via.placeholder.com/15/a9a9a9/000000?text=+)
+report.state.open=  ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+)
+report.state.old=  ![#ffaa00](https://via.placeholder.com/15/ffaa00/000000?text=+)
+report.state.ancient=  ![#ff0000](https://via.placeholder.com/15/ff0000/000000?text=+)
+
 #
 # Hibernate Configuraton
 #

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -43,8 +43,8 @@ jira.users=
 ##########
 report.weekly.name=Weekly Report
 
-report.state.closed=  ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+)
-report.state.open=  ![#0000ff](https://via.placeholder.com/15/0000ff/000000?text=+)
+report.state.closed=  ![#a9a9a9](https://via.placeholder.com/15/a9a9a9/000000?text=+)
+report.state.open=  ![#00ff00](https://via.placeholder.com/15/00ff00/000000?text=+)
 report.state.old=  ![#ffaa00](https://via.placeholder.com/15/ffaa00/000000?text=+)
 report.state.ancient=  ![#ff0000](https://via.placeholder.com/15/ff0000/000000?text=+)
 


### PR DESCRIPTION
## TODO

Improve weekly report generated to 
- [x] Display the full user name and not our github acronym: cmoulliard -> Charles Moulliard within the report - https://github.com/snowdrop-bot/snowdrop-bot/issues/71
- [x] Rename the title to "Weekly Report - 22"
- [x] Sort the issues / project and/or module and status
- [x] Display the status using colors and not using black text - `[closed]`