### PR TITLE
fix: container timezone to Europe/Madrid

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -18,11 +18,15 @@ FROM fabric8/java-alpine-openjdk11-jre:1.8
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV AB_ENABLED=jmx_exporter
 
+RUN mkdir -p /z/var/snowdrop-bot
+
 # Be prepared for running in OpenShift too
 RUN adduser -G root --no-create-home --disabled-password 1001 \
   && chown -R 1001 /deployments \
   && chmod -R "g+rwX" /deployments \
-  && chown -R 1001:root /deployments
+  && chown -R 1001:root /deployments \
+  && chown -R 1001:root /z \
+  && chmod -R "g+rwX" /z
 
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -17,6 +17,9 @@
 FROM fabric8/java-alpine-openjdk11-jre:1.8
 ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV AB_ENABLED=jmx_exporter
+ENV TZ=Europe/Madrid
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN mkdir -p /z/var/snowdrop-bot
 


### PR DESCRIPTION
The timezone was set to Europe/Madrid because the bot application was running 2 hours behind regarding CET.

Closes #106 