### PR TITLE
fix (#111): GithubIssueBridge now clears cache on refresh.

### DIFF
--- a/src/main/java/io/snowdrop/github/issues/GithubIssueBridge.java
+++ b/src/main/java/io/snowdrop/github/issues/GithubIssueBridge.java
@@ -77,6 +77,11 @@ public class GithubIssueBridge {
 
   public void refresh() {
     LOGGER.info("Refershing bridge: {} -> {}.", sourceRepository, targetRepository);
+
+    openIssues.clear();
+    closedIssues.clear();
+    downstreamIssues.clear();
+
     downstreamOpenIssues().stream().forEach(i -> downstreamIssues.put(i.getNumber(), i));
     LOGGER.info("Downstream issue count: {} -> {}.", targetRepository, downstreamIssues.size());
 


### PR DESCRIPTION
Resolves: #111 

I think that the root cause is the fact  that we cache everything and never invalidate. The pr clears the cache each time we refresh.