### PR TITLE
chore: update the documentation after problems with a defected secret value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.snowdrop</groupId>
   <artifactId>snowdrop-bot</artifactId>
-  <version>0.11</version>
+  <version>0.12-SNAPSHOT</version>
   <properties>
     <dekorate.version>1.0.0</dekorate.version>
     <egit-github.version>2.1.5</egit-github.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.snowdrop</groupId>
   <artifactId>snowdrop-bot</artifactId>
-  <version>0.10</version>
+  <version>0.11-SNAPSHOT</version>
   <properties>
     <dekorate.version>1.0.0</dekorate.version>
     <egit-github.version>2.1.5</egit-github.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.snowdrop</groupId>
   <artifactId>snowdrop-bot</artifactId>
-  <version>0.11-SNAPSHOT</version>
+  <version>0.11</version>
   <properties>
     <dekorate.version>1.0.0</dekorate.version>
     <egit-github.version>2.1.5</egit-github.version>

--- a/src/main/kubernetes/snowdrop-associates.yaml.template
+++ b/src/main/kubernetes/snowdrop-associates.yaml.template
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: snowdrop-associates
+  namespace: bot
+data:
+  github.users: <base64 list of the associates>
+type: Opaque

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -122,6 +122,7 @@ quarkus.kubernetes.deployment-target=openshift, kubernetes
 quarkus.kubernetes.part-of=snowdrop-bot
 quarkus.kubernetes.env-vars.snowdrop-github.secret=snowdrop-github
 quarkus.kubernetes.env-vars.snowdrop-jira.secret=snowdrop-jira
+quarkus.kubernetes.env-vars.snowdrop-associates.secret=snowdrop-associates
 
 # Mount PVC volume
 quarkus.kubernetes.pvc-volumes.snowdrop-db.claim-name=snowdrop-db-claim

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -117,6 +117,11 @@ google.docs.report.document-id=1WPefEYU_KUG8QdsqV3-mwdVUaL9tlUm1A5nKsVgDWGE
 #
 
 quarkus.kubernetes.deployment-target=openshift, kubernetes
+quarkus.kubernetes.expose=true
+
+quarkus.container-image.group=snowdrop
+quarkus.container-image.name=snowdrop-bot
+quarkus.container-image.registry=quay.io
 
 # Kubernetes specific resources
 quarkus.kubernetes.part-of=snowdrop-bot
@@ -125,17 +130,12 @@ quarkus.kubernetes.env-vars.snowdrop-jira.secret=snowdrop-jira
 quarkus.kubernetes.env-vars.snowdrop-associates.secret=snowdrop-associates
 
 # Mount PVC volume
-quarkus.kubernetes.pvc-volumes.snowdrop-db.claim-name=snowdrop-db-claim
-quarkus.kubernetes.mounts.snowdrop-db.path=/z/var/snowdrop-bot/data/prod
+#quarkus.kubernetes.pvc-volumes.snowdrop-db.claim-name=snowdrop-db-claim
+#quarkus.kubernetes.mounts.snowdrop-db.path=/z/var/snowdrop-bot/data/prod
 
 # Openshift specific resources
 quarkus.openshift.part-of=snowdrop-bot
 quarkus.openshift.env-vars.snowdrop-github.secret=snowdrop-github
-
-# Mount PVC volume
-quarkus.openshift.pvc-volumes.snowdrop-db.claim-name=snowdrop-db-claim
-quarkus.openshift.mounts.snowdrop-db.path=/z/var/snowdrop-bot/data/db
-
 
 quarkus.kubernetes-client.trust-certs=true
 


### PR DESCRIPTION
This doc improvement tries to improve the docs so issues such as #123 don't happen again (Preventive Action). The  problem with this issue was a defected creation of the `github.users` secret. It had a NL at the end. The docs have been updated so this situation doesn't happen again. Moreover the steps to publish the bot on k8s have also been improved.

Also added parameters to the `application.properties` file in order to have the pod source and naming right.

Closes #123 