### PR TITLE
Issue150 state update

### DIFF
--- a/src/main/java/io/snowdrop/github/issues/GithubIssueBridge.java
+++ b/src/main/java/io/snowdrop/github/issues/GithubIssueBridge.java
@@ -125,6 +125,7 @@ public class GithubIssueBridge {
    */
   public List<Issue> teamOpenIssues() {
     return source().filter(i -> i.getAssignee() != null && users.contains(i.getAssignee().getLogin()))
+        .filter(issue -> issue.getHtmlUrl().contains("issues"))
         .collect(Collectors.toList());
   }
 
@@ -136,7 +137,7 @@ public class GithubIssueBridge {
   public List<Issue> teamClosedIssues() {
     return source(Github.params().closed().build())
         .filter(i -> i.getAssignee() != null && users.contains(i.getAssignee().getLogin()))
-        .filter(issue -> issue.getHtmlUrl().contains("issue"))
+        .filter(issue -> issue.getHtmlUrl().contains("issues"))
         .collect(Collectors.toList());
   }
 

--- a/src/main/java/io/snowdrop/github/issues/GithubIssueBridge.java
+++ b/src/main/java/io/snowdrop/github/issues/GithubIssueBridge.java
@@ -119,7 +119,7 @@ public class GithubIssueBridge {
   }
 
   /**
-   * Stream all the open issues of the source repository assigned to team mebmers.
+   * Stream all the open issues of the source repository assigned to team members.
    *
    * @return A stream of issues.
    */
@@ -136,6 +136,7 @@ public class GithubIssueBridge {
   public List<Issue> teamClosedIssues() {
     return source(Github.params().closed().build())
         .filter(i -> i.getAssignee() != null && users.contains(i.getAssignee().getLogin()))
+        .filter(issue -> issue.getHtmlUrl().contains("issue"))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
[From the doc](https://docs.github.com/en/rest/reference/issues#list-organization-issues-assigned-to-the-authenticated-user) : _The GitHub's REST API v3 considers every pull request an issue, but not every issue is a pull request. For this reason, "Issues" endpoints may return both issues and pull requests in the response_ .
So `issueService.getIssues(Github.user(repo), Github.repo(repo), params)` returns all the `issues` and `pull requests` matching with the state passed in the `params` parameter. In this case, we only want to get the upstream issues in order to clone/close the downstream corresponding ones.

I don't like the way I'm filtering but I tried to add another filter `is:issue` in the params but it didn't work, I need to investigate more or maybe to open an issue in the `github.core` repo.

Related to #150 